### PR TITLE
Fixed an error in check for existing smilies

### DIFF
--- a/ImpExDatabaseCore.php
+++ b/ImpExDatabaseCore.php
@@ -6754,7 +6754,7 @@ class ImpExDatabaseCore extends ImpExFunction
 	* @param	object	databaseobject	The database that the function is going to interact with.
 	* @param	string	mixed			The type of database 'mysql', 'postgresql', etc
 	* @param	string	mixed			The prefix to the table name i.e. 'vb3_'
-	* @param	string	mixed			array( title => '', smilietext => '', smiliepath => '')
+	* @param	string				Smilie text
 	*
 	* @return	boolean
 	*/
@@ -6765,7 +6765,7 @@ class ImpExDatabaseCore extends ImpExFunction
 			// MySQL database
 			case 'mysql':
 			{
-				return $Db_object->query_first("SELECT smilieid FROM " . $tableprefix . "smilie WHERE smilietext='". addslashes($smilie['smilietext']) ."'");
+				return $Db_object->query_first("SELECT smilieid FROM " . $tableprefix . "smilie WHERE smilietext='". addslashes($smilie) ."'");
 			}
 
 			// Postgres database


### PR DESCRIPTION
Also, addslashes() is already applied to the input smilie before calling, so I'm not sure whether it's correct to perform addslashes() again inside the function. I haven't checked whether it actually has to be applied twice.

However, the array thing was definitely wrong.

I know this hasn't been touched for 5 years, but there are still vBulletin 3.7 forums out there, and if I'm using this I can't be the only one.